### PR TITLE
Fix backup step typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you have an existing vim configuration, first move it out of the way. You can
     $ cd
     $ mv .vim .vim.bak
     $ mv .vimrc .vimrc.bak
-    $ mv .gvimrc .gvimrc
+    $ mv .gvimrc .gvimrc.bak
 
 Now clone this repo into ~/.vim and set it up:
 


### PR DESCRIPTION
Properly backup gvimrc to a different filename.
